### PR TITLE
UploadSelect not working with IE9+

### DIFF
--- a/src/client/filetransfer/Sync.UploadSelect.js
+++ b/src/client/filetransfer/Sync.UploadSelect.js
@@ -237,7 +237,7 @@ FileTransfer.Sync.DefaultUploadRender = Core.extend(FileTransfer.Sync.UploadRend
     /** @see FileTransfer.Sync.UploadRender#add */
     add: function() {
         // Render Target IFRAME and form.
-        if (Core.Web.Env.BROWSER_INTERNET_EXPLORER) {
+        if (Core.Web.Env.BROWSER_INTERNET_EXPLORER  && Core.Web.Env.BROWSER_VERSION_MAJOR < 9) {
             // Target IFRAME must be created using innerHTML for IE or it will not be targeted by the upload form.
             var iframeSrc = "<iframe " +
                     "name=\"" + this.peer.component.renderId + "_target\" " +


### PR DESCRIPTION
The UploadSelect leads to an error in IE9+
this commit fixes this error.
There is no IE-specific code necessary for IE9+ so the 'default' code for all other browser could be used for IE9+ too.

See also discussion on forum:
http://echo.nextapp.com/site/node/6609
