### PR TITLE
Bugfix of "file upload limit exceeded" handling

### DIFF
--- a/.idea/artifacts/echo3_filetransfer_testapp.xml
+++ b/.idea/artifacts/echo3_filetransfer_testapp.xml
@@ -20,10 +20,10 @@
           </element>
         </element>
         <element id="directory" name="lib">
-          <element id="file-copy" path="$PROJECT_DIR$/lib/commons-io-1.3.2.jar" />
-          <element id="file-copy" path="$PROJECT_DIR$/lib/commons-fileupload-1.2.jar" />
           <element id="library" level="module" name="echo3-webcontainer-3.0.0" module-name="echo3-filetransfer" />
           <element id="library" level="module" name="echo3-app-3.0.0" module-name="echo3-filetransfer" />
+          <element id="file-copy" path="$PROJECT_DIR$/lib/commons-fileupload-1.3.jar" />
+          <element id="file-copy" path="$PROJECT_DIR$/lib/commons-io-2.2.jar" />
         </element>
       </element>
       <element id="dir-copy" path="$PROJECT_DIR$/src/server-java/testapp/htdocs" />

--- a/ant.properties
+++ b/ant.properties
@@ -7,8 +7,8 @@ ant.build.javac.target                  1.4
 servlet.lib.jar                         lib/servlet-api-2.4.jar
 echo3.app.lib.jar                       lib/echo3-app-${echo.version}.jar
 echo3.webcontainer.lib.jar              lib/echo3-webcontainer-${echo.version}.jar
-filetransfer.commons-io.lib.jar         lib/commons-io-1.3.2.jar
-filetransfer.commons-fileupload.lib.jar	lib/commons-fileupload-1.2.jar
+filetransfer.commons-io.lib.jar         lib/commons-io-2.2.jar
+filetransfer.commons-fileupload.lib.jar	lib/commons-fileupload-1.3.jar
 
 debug                                   yes
 jarfile.filetransfer.model              echo3-filetransfer-model-${release.version}.jar

--- a/build.xml
+++ b/build.xml
@@ -67,10 +67,10 @@
             <dependency groupId="com.nextapp" artifactId="echo3-webcontainer" version="${echo.version}" classifier="sources"/>
             <dependency groupId="javax.servlet" artifactId="servlet-api" version="2.4"/>
             <dependency groupId="javax.servlet" artifactId="servlet-api" version="2.4" classifier="sources"/>
-            <dependency groupId="commons-io" artifactId="commons-io" version="1.3.2"/>
-            <dependency groupId="commons-io" artifactId="commons-io" version="1.3.2" classifier="sources"/>
-            <dependency groupId="commons-fileupload" artifactId="commons-fileupload" version="1.2"/>
-            <dependency groupId="commons-fileupload" artifactId="commons-fileupload" version="1.2" classifier="sources"/>
+            <dependency groupId="commons-io" artifactId="commons-io" version="2.2"/>
+            <dependency groupId="commons-io" artifactId="commons-io" version="2.2" classifier="sources"/>
+            <dependency groupId="commons-fileupload" artifactId="commons-fileupload" version="1.3"/>
+            <dependency groupId="commons-fileupload" artifactId="commons-fileupload" version="1.3" classifier="sources"/>
         </artifact:dependencies>
 
         <copy todir="${dir.lib}">

--- a/echo3-filetransfer.iml
+++ b/echo3-filetransfer.iml
@@ -45,24 +45,24 @@
       </library>
     </orderEntry>
     <orderEntry type="module-library" exported="">
-      <library name="commons-io-1.3.2">
+      <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/commons-io-1.3.2.jar!/" />
+          <root url="jar://$MODULE_DIR$/lib/commons-io-2.2.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/commons-io-1.3.2-sources.jar!/" />
+          <root url="jar://$MODULE_DIR$/lib/commons-io-2.2-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>
     <orderEntry type="module-library" exported="">
-      <library name="commons-fileupload-1.2">
+      <library>
         <CLASSES>
-          <root url="jar://$MODULE_DIR$/lib/commons-fileupload-1.2.jar!/" />
+          <root url="jar://$MODULE_DIR$/lib/commons-fileupload-1.3.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES>
-          <root url="jar://$MODULE_DIR$/lib/commons-fileupload-1.2-sources.jar!/" />
+          <root url="jar://$MODULE_DIR$/lib/commons-fileupload-1.3-sources.jar!/" />
         </SOURCES>
       </library>
     </orderEntry>

--- a/src/server-java/receiver/nextapp/echo/filetransfer/receiver/JakartaUploadProcessor.java
+++ b/src/server-java/receiver/nextapp/echo/filetransfer/receiver/JakartaUploadProcessor.java
@@ -218,6 +218,7 @@ implements UploadProcessor {
             
             uploadProcess = UploadProcessManager.get(request, id, true);
             uploadProcess.addProcessListener(uploadProcessListener);
+            currentUpload = null;
             try {
                 FileItemIterator iter = sfu.getItemIterator(request);
                 int uploadIndex = 0;
@@ -240,6 +241,13 @@ implements UploadProcessor {
                     }
                 }
             } catch (SizeLimitExceededException ex) {
+                if (currentUpload == null) {
+                    /* If currentUpload is null, the SizeLimitExceededException was thrown
+                       because the fileupload library detected that the content length specified
+                       in the request's header is too large, before any upload objects could be created.
+                       In this case, create a dummy Upload object to set the status on to inform the listeners.*/
+                    uploadProcess.createUpload();
+                }
                 uploadProcess.setStatus(Upload.STATUS_ERROR_OVERSIZE);
             } catch (IOException ex) {
                 uploadProcess.setStatus(Upload.STATUS_ERROR_IO);


### PR DESCRIPTION
The commons-fileupload implementation detects too large uploads already when reading the content size from the request header. The resulting exception was thrown before any uploads, on which the STATUS_ERROR_OVERSIZE could be set, were registered in the upload processor. This meant the listeners were never notified of the error.

This fix creates a dummy upload object in this case, on which the status can be set and with which the listeners can be notified.
