### PR TITLE
New UploadListener "uploadSend" event 

### DIFF
--- a/src/client/filetransfer/Application.UploadSelect.js
+++ b/src/client/filetransfer/Application.UploadSelect.js
@@ -98,7 +98,7 @@ FileTransfer.AbstractUploadSelect = Core.extend(Echo.Component, {
             return;
         }
         this.sending = true;
-        this.fireEvent({ source: this, type: "uploadSend" });
+        this.fireEvent({ source: this, type: "uploadSend", data: this.processId });
     }
 });
 

--- a/src/server-java/app/nextapp/echo/filetransfer/app/AbstractUploadSelect.java
+++ b/src/server-java/app/nextapp/echo/filetransfer/app/AbstractUploadSelect.java
@@ -50,6 +50,7 @@ public abstract class AbstractUploadSelect extends Component {
     
     public static final String UPLOAD_LISTENERS_CHANGED_PROPERTY = "uploadListeners";
     public static final String UPLOAD_PROGRESS_LISTENERS_CHANGED_PROPERTY = "uploadProgressListeners";
+    public static final String INPUT_UPLOAD_SEND = "uploadSend";
     public static final String INPUT_UPLOAD_COMPLETE = "uploadComplete";
 
     public static final String PROPERTY_INSETS = "insets";
@@ -139,6 +140,16 @@ public abstract class AbstractUploadSelect extends Component {
             ((UploadListener) listeners[i]).uploadComplete(e);
         }
     }
+
+    /**
+     * Provides notification that the component now starts with an upload.
+     */
+    public void doUploadSend() {
+        EventListener[] listeners = getEventListenerList().getListeners(UploadListener.class);
+        for (int i = 0; i < listeners.length; ++i){
+            ((UploadListener) listeners[i]).uploadSend();
+        }
+    }
     
     /**
      * Provides notification that the specified upload has progressed.
@@ -199,6 +210,8 @@ public abstract class AbstractUploadSelect extends Component {
             for (int i = 0; i < uploads.length; ++i) {
                 doUploadComplete(uploads[i]);
             }
+        } else if (INPUT_UPLOAD_SEND.equals(inputName)) {
+            doUploadSend();
         }
     }
     

--- a/src/server-java/app/nextapp/echo/filetransfer/app/event/UploadListener.java
+++ b/src/server-java/app/nextapp/echo/filetransfer/app/event/UploadListener.java
@@ -44,4 +44,11 @@ public interface UploadListener extends EventListener  {
      * @param e the <code>UploadEvent</code> describing the upload
      */
     public void uploadComplete(UploadEvent e);
+
+    /**
+     * Invoked to indicate the start of a file upload.
+     * This method will be invoked by a user interface thread, enabling the user interface state to
+     * be changed as a result.
+     */
+    public void uploadSend();
 }

--- a/src/server-java/testapp/lib/nextapp/echo/filetransfer/testapp/testscreen/MultipleUploadSelectTest.java
+++ b/src/server-java/testapp/lib/nextapp/echo/filetransfer/testapp/testscreen/MultipleUploadSelectTest.java
@@ -216,6 +216,11 @@ public class MultipleUploadSelectTest extends SplitPane {
                 } 
 
             }
+
+            @Override
+            public void uploadSend() {
+                InteractiveApp.getApp().consoleWrite("Upload SEND");
+            }
         });
         testColumn.add(uploadSelect);
         add(testColumn);

--- a/src/server-java/testapp/lib/nextapp/echo/filetransfer/testapp/testscreen/UploadSelectTest.java
+++ b/src/server-java/testapp/lib/nextapp/echo/filetransfer/testapp/testscreen/UploadSelectTest.java
@@ -29,15 +29,7 @@
 
 package nextapp.echo.filetransfer.testapp.testscreen;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Random;
-import nextapp.echo.app.Border;
-import nextapp.echo.app.Button;
-import nextapp.echo.app.Color;
-import nextapp.echo.app.Column;
-import nextapp.echo.app.Insets;
-import nextapp.echo.app.SplitPane;
+import nextapp.echo.app.*;
 import nextapp.echo.app.event.ActionEvent;
 import nextapp.echo.app.event.ActionListener;
 import nextapp.echo.filetransfer.app.UploadSelect;
@@ -49,15 +41,20 @@ import nextapp.echo.filetransfer.receiver.JakartaUploadProcessor;
 import nextapp.echo.filetransfer.testapp.ButtonColumn;
 import nextapp.echo.filetransfer.testapp.InteractiveApp;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Random;
+
 public class UploadSelectTest extends SplitPane {
     
     private UploadSelect uploadSelect;
+    private Label uploadLabel;
     private boolean cancelUploads = false;
     private boolean cancelUploadsA = false;
     
     public UploadSelectTest() {
         setStyleName("TestControls");
-        ButtonColumn controlsColumn = new ButtonColumn();
+        final ButtonColumn controlsColumn = new ButtonColumn();
         controlsColumn.setStyleName("TestControlsColumn");
         add(controlsColumn);
         
@@ -149,9 +146,10 @@ public class UploadSelectTest extends SplitPane {
             }
         });
 
-        Column testColumn = new Column();
+        final Column testColumn = new Column();
         
         uploadSelect = new UploadSelect();
+        uploadLabel = new Label();
         uploadSelect.addUploadProgressListener(new UploadProgressListener() {
         
             public void uploadStart(UploadEvent e) {
@@ -172,65 +170,73 @@ public class UploadSelectTest extends SplitPane {
             }
         });
         uploadSelect.addUploadListener(new UploadListener() {
-        
+
             public void uploadComplete(UploadEvent e) {
                 try {
                     Upload upload = e.getUpload();
                     switch (upload.getStatus()) {
-                    case Upload.STATUS_COMPLETE:
-                        InteractiveApp.getApp().consoleWrite("Upload COMPLETE: " + e.getUpload());
-                        InputStream in = null;
-                        try {
-                            byte[] buffer = new byte[4096];
-                            int n = 0;
-                            int bytes = 0;
-                            in = e.getUpload().getInputStream();
-                            while (-1 != (n = in.read(buffer))) {
-                                bytes += n;
-                            }
-                            InteractiveApp.getApp().consoleWrite("Read: " + bytes + " bytes.");
-                        } catch (IOException ex) {
-                            InteractiveApp.getApp().consoleWrite("EXCEPTION: " + ex);
-                        } finally {
+                        case Upload.STATUS_COMPLETE:
+                            InteractiveApp.getApp().consoleWrite("Upload COMPLETE: " + e.getUpload());
+                            InputStream in = null;
                             try {
-                                in.close();
+                                byte[] buffer = new byte[4096];
+                                int n = 0;
+                                int bytes = 0;
+                                in = e.getUpload().getInputStream();
+                                while (-1 != (n = in.read(buffer))) {
+                                    bytes += n;
+                                }
+                                InteractiveApp.getApp().consoleWrite("Read: " + bytes + " bytes.");
                             } catch (IOException ex) {
                                 InteractiveApp.getApp().consoleWrite("EXCEPTION: " + ex);
+                            } finally {
+                                try {
+                                    in.close();
+                                } catch (IOException ex) {
+                                    InteractiveApp.getApp().consoleWrite("EXCEPTION: " + ex);
+                                }
                             }
-                        }                    
-                        break;
-                    case Upload.STATUS_CANCELED:
-                        if (e.getUpload().getInputStream() != null) {
-                            throw new RuntimeException("InputStream available for failed upload, this should not happen");
-                        }
-                        InteractiveApp.getApp().consoleWrite("Upload CANCELED: " + e.getUpload());
-                        break;
-                    case Upload.STATUS_ERROR_IO:
-                        if (e.getUpload().getInputStream() != null) {
-                            throw new RuntimeException("InputStream available for failed upload, this should not happen");
-                        }
-                        InteractiveApp.getApp().consoleWrite("Upload ERROR IO: " + e.getUpload());
-                        break;
-                    case Upload.STATUS_ERROR_OVERSIZE:
-                        if (e.getUpload().getInputStream() != null) {
-                            throw new RuntimeException("InputStream available for failed upload, this should not happen");
-                        }
-                        InteractiveApp.getApp().consoleWrite("Upload ERROR OVERSIZE: " + e.getUpload());
-                        break;
-                    case Upload.STATUS_IN_PROGRESS:
-                        InteractiveApp.getApp().consoleWrite("Upload IN PROGRESS: " + e.getUpload());
-                        break;
-                    default:
-                        InteractiveApp.getApp().consoleWrite("Unexpected status: " + e.getUpload());
-                        break;
-                    } 
+                            break;
+                        case Upload.STATUS_CANCELED:
+                            if (e.getUpload().getInputStream() != null) {
+                                throw new RuntimeException("InputStream available for failed upload, this should not happen");
+                            }
+                            InteractiveApp.getApp().consoleWrite("Upload CANCELED: " + e.getUpload());
+                            break;
+                        case Upload.STATUS_ERROR_IO:
+                            if (e.getUpload().getInputStream() != null) {
+                                throw new RuntimeException("InputStream available for failed upload, this should not happen");
+                            }
+                            InteractiveApp.getApp().consoleWrite("Upload ERROR IO: " + e.getUpload());
+                            break;
+                        case Upload.STATUS_ERROR_OVERSIZE:
+                            if (e.getUpload().getInputStream() != null) {
+                                throw new RuntimeException("InputStream available for failed upload, this should not happen");
+                            }
+                            InteractiveApp.getApp().consoleWrite("Upload ERROR OVERSIZE: " + e.getUpload());
+                            break;
+                        case Upload.STATUS_IN_PROGRESS:
+                            InteractiveApp.getApp().consoleWrite("Upload IN PROGRESS: " + e.getUpload());
+                            break;
+                        default:
+                            InteractiveApp.getApp().consoleWrite("Unexpected status: " + e.getUpload());
+                            break;
+                    }
+                    uploadLabel.setText("Upload finished");
                 } catch (IOException ex) {
                     ex.printStackTrace();
                     InteractiveApp.getApp().consoleWrite(ex.toString());
                 }
             }
+
+            @Override
+            public void uploadSend() {
+                InteractiveApp.getApp().consoleWrite("Upload SEND");
+                uploadLabel.setText("Upload started");
+            }
         });
         testColumn.add(uploadSelect);
+        testColumn.add(uploadLabel);
         add(testColumn);
     }
 }

--- a/src/server-java/webcontainer/nextapp/echo/filetransfer/webcontainer/AbstractUploadSelectPeer.java
+++ b/src/server-java/webcontainer/nextapp/echo/filetransfer/webcontainer/AbstractUploadSelectPeer.java
@@ -89,6 +89,24 @@ public abstract class AbstractUploadSelectPeer extends AbstractComponentSynchron
                 return true;
             }
         });
+        addEvent(new EventPeer(AbstractUploadSelect.INPUT_UPLOAD_SEND, AbstractUploadSelect.UPLOAD_LISTENERS_CHANGED_PROPERTY) {
+            /**
+             * @see nextapp.echo.webcontainer.AbstractComponentSynchronizePeer.EventPeer#processEvent(
+             *      nextapp.echo.app.util.Context, nextapp.echo.app.Component, java.lang.Object)
+             */
+            public void processEvent(Context context, Component component, Object eventData) {
+                Connection conn = (Connection) context.get(Connection.class);
+                super.processEvent(context, component, eventData);
+            }
+
+            /**
+             * @see nextapp.echo.webcontainer.AbstractComponentSynchronizePeer.EventPeer#hasListeners(
+             *      nextapp.echo.app.util.Context, nextapp.echo.app.Component)
+             */
+            public boolean hasListeners(Context context, Component c) {
+                return true;
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
Upload listeners can now get notified for the event that an upload
is started. While the "uploadStart" event in UploadProcessListener
does not allow user interface modifications because it runs outside of
user interface threads, this event does.
